### PR TITLE
Generalize argument parsing

### DIFF
--- a/src/argument/command.rs
+++ b/src/argument/command.rs
@@ -1,0 +1,30 @@
+#[derive(Debug)]
+pub enum Command {
+    Mark,
+    Marks,
+    Unmark,
+}
+
+pub fn get_command_from_args(arg: Option<String>) -> Result<Command, &'static str> {
+    match arg {
+        None => {
+            Err("No command provided. Expected one of mark, marks, unmark")
+        },
+        Some(command) => {
+            match command.as_str() {
+                "mark" => {
+                    Ok(Command::Mark)
+                },
+                "marks" => {
+                    Ok(Command::Marks)
+                },
+                "unmark" => {
+                    Ok(Command::Unmark)
+                },
+                _ => {
+                    Err("Unexpected command. Expected one of mark, marks, unmark")
+                }
+            }
+        }
+    }
+}

--- a/src/argument/date.rs
+++ b/src/argument/date.rs
@@ -1,35 +1,65 @@
-use chrono::NaiveDate;
+use chrono::{Duration, NaiveDate};
+use inquire::DateSelect;
 
-pub fn get_date_from_args(_arg: String) -> Result<NaiveDate, &'static str> {
-    let arg = _arg.as_str();
+enum DateOption {
+    Past,
+    Exact(NaiveDate),
+    Future
+}
 
-    if arg.starts_with("--today") {
-        let mut anchor = chrono::Local::now().date_naive();
-        let offset = arg.replace("--today", "");
+pub fn get_date_from_args(_arg: Option<String>) -> Result<NaiveDate, &'static str> {
+    let arg = match _arg {
+        None => { return Err("No date option provided. Expected one of --past, --today, --future"); },
+        Some(a) => { a.as_str() }
+    };
 
-        anchor += match offset.chars().next() {
-            None => {
-                chrono::Duration::days(0)
-            },
-            Some('+') => {
-                let offset = offset[1..].parse::<i64>().expect("Invalid offset");
-                chrono::Duration::days(offset)
-            },
-            Some('-') => {
-                let offset = offset[1..].parse::<i64>().expect("Invalid offset");
-                chrono::Duration::days(-offset)
-            },
-            Some(_) => {
-                return Err("Invalid operator");
+    let date_option = match arg {
+        "--past" => DateOption::Past,
+        "--future" => DateOption::Future,
+        _ => {
+            if arg.starts_with("--today") {
+                let mut anchor = chrono::Local::now().date_naive();
+                let offset = arg.replace("--today", "");
+
+                anchor += match offset.chars().next() {
+                    None => {
+                        Duration::days(0)
+                    },
+                    Some('+') => {
+                        let offset = offset[1..].parse::<i64>().expect("Invalid offset");
+                        Duration::days(offset)
+                    },
+                    Some('-') => {
+                        let offset = offset[1..].parse::<i64>().expect("Invalid offset");
+                        Duration::days(-offset)
+                    },
+                    Some(_) => {
+                        return Err("Invalid operator");
+                    }
+                };
+
+                DateOption::Exact(anchor)
+            } else {
+                return Err("Invalid date option")
             }
-        };
+        }
+    };
 
-        Ok(anchor)
-    } else if arg.starts_with("--date=") {
-        let date = arg.replace("--date=", "");
-        let parsed_date = NaiveDate::parse_from_str(date.as_str(), "%Y-%m-%d").expect("Invalid date format, expected YYYY-MM-DD");
-        Ok(parsed_date)
-    } else {
-        Err("Invalid argument")
-    }
+    let date = match date_option {
+        DateOption::Past => {
+            DateSelect::new("Date")
+                .with_max_date(chrono::Local::now().date_naive() - Duration::days(1))
+                .with_help_message("Enter a past date for mark")
+                .prompt().unwrap()
+        },
+        DateOption::Exact(date) => { date },
+        DateOption::Future => {
+            DateSelect::new("Date")
+                .with_min_date(chrono::Local::now().date_naive() + Duration::days(1))
+                .with_help_message("Enter a past date for mark")
+                .prompt().unwrap()
+        }
+    };
+
+    Ok(date)
 }

--- a/src/argument/date.rs
+++ b/src/argument/date.rs
@@ -19,8 +19,8 @@ pub fn get_date_from_args(_arg: String) -> Result<NaiveDate, &'static str> {
                 let offset = offset[1..].parse::<i64>().expect("Invalid offset");
                 chrono::Duration::days(-offset)
             },
-            Some(c) => {
-                panic!("Invalid operator '{}'", c);
+            Some(_) => {
+                return Err("Invalid operator");
             }
         };
 

--- a/src/argument/date.rs
+++ b/src/argument/date.rs
@@ -10,10 +10,10 @@ enum DateOption {
 pub fn get_date_from_args(_arg: Option<String>) -> Result<NaiveDate, &'static str> {
     let arg = match _arg {
         None => { return Err("No date option provided. Expected one of --past, --today, --future"); },
-        Some(a) => { a.as_str() }
+        Some(a) => { a }
     };
 
-    let date_option = match arg {
+    let date_option = match arg.as_str() {
         "--past" => DateOption::Past,
         "--future" => DateOption::Future,
         _ => {

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -1,15 +1,34 @@
-pub mod date;
+use chrono::NaiveDate;
+
+mod date;
 mod command;
 
-pub fn get_arguments() -> Result<Vec<String>, String> {
+#[derive(Debug)]
+pub struct Arguments {
+    command: command::Command,
+    date: NaiveDate
+}
+
+pub fn get_arguments() -> Result<Arguments, String> {
     let mut arguments = std::env::args();
     arguments.next(); // Skip the first argument
 
     let potential_command = arguments.next();
     let command = command::get_command_from_args(potential_command)?;
-    println!("{:?}", command);
 
-    let args = arguments.collect::<Vec<String>>();
+    let mut date: Option<NaiveDate> = None;
+    for arg in arguments {
+        if date.is_some() { break }
+        match date::get_date_from_args(arg) {
+            Ok(d) => { date = Some(d); },
+            Err(_) => {}
+        }
+    }
+
+    let args = Arguments {
+        command,
+        date: date.ok_or("A date argument is required")?
+    };
 
     Ok(args)
 }

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -16,14 +16,8 @@ pub fn get_arguments() -> Result<Arguments, String> {
     let potential_command = arguments.next();
     let command = command::get_command_from_args(potential_command)?;
 
-    let mut date: Option<NaiveDate> = None;
-    for arg in arguments {
-        if date.is_some() { break }
-        match date::get_date_from_args(arg) {
-            Ok(d) => { date = Some(d); },
-            Err(_) => {}
-        }
-    }
+    let potential_date = arguments.next();
+    let date = date::get_date_from_args(potential_date)?;
 
     let args = Arguments {
         command,

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -1,12 +1,12 @@
 use chrono::NaiveDate;
 
 mod date;
-mod command;
+pub mod command;
 
 #[derive(Debug)]
 pub struct Arguments {
-    command: command::Command,
-    date: NaiveDate
+    pub command: command::Command,
+    pub date: NaiveDate
 }
 
 pub fn get_arguments() -> Result<Arguments, String> {

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -17,11 +17,11 @@ pub fn get_arguments() -> Result<Arguments, String> {
     let command = command::get_command_from_args(potential_command)?;
 
     let potential_date = arguments.next();
-    let date = date::get_date_from_args(potential_date)?;
+    let date = date::get_date_from_args(potential_date);
 
     let args = Arguments {
         command,
-        date: date.ok_or("A date argument is required")?
+        date: date?,
     };
 
     Ok(args)

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -1,1 +1,15 @@
 pub mod date;
+mod command;
+
+pub fn get_arguments() -> Result<Vec<String>, String> {
+    let mut arguments = std::env::args();
+    arguments.next(); // Skip the first argument
+
+    let potential_command = arguments.next();
+    let command = command::get_command_from_args(potential_command)?;
+    println!("{:?}", command);
+
+    let args = arguments.collect::<Vec<String>>();
+
+    Ok(args)
+}

--- a/src/command/mark.rs
+++ b/src/command/mark.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 use chrono::{NaiveDate};
-use inquire::{DateSelect, Editor, required, Text};
+use inquire::{Editor, required, Text};
 use tokio_postgres::Client;
 use crate::config;
 
@@ -8,16 +8,15 @@ use crate::config;
 struct InputMark {
     title: Option<String>,
     note: String,
-    date: Option<NaiveDate>,
 }
 
-fn get_input_for_mark(should_provide_date_picker: bool) -> InputMark {
+fn get_input_for_mark() -> InputMark {
     let guard = config::CONFIG.lock().unwrap();
     let config = guard.as_ref().unwrap();
     let mark_style = &config.mark_style;
     let editor = &config.editor;
 
-    let mut input_mark = match mark_style {
+    let input_mark = match mark_style {
         config::MarkStyle::Default => {
             let _note = Text::new("Mark")
                 .with_placeholder("Some text to be marked")
@@ -28,7 +27,6 @@ fn get_input_for_mark(should_provide_date_picker: bool) -> InputMark {
             InputMark {
                 title: None,
                 note: _note,
-                date: None,
             }
         },
 
@@ -48,35 +46,20 @@ fn get_input_for_mark(should_provide_date_picker: bool) -> InputMark {
             InputMark {
                 title: Some(_title),
                 note: _note,
-                date: None,
             }
         },
     };
 
-    match should_provide_date_picker {
-        true => {
-            let _date = DateSelect::new("Date")
-                .with_help_message("Enter date.rs for mark")
-                .prompt().unwrap();
-
-            input_mark.date = Some(_date);
-        },
-        false => {},
-    }
-
     return input_mark;
 }
 
-pub async fn add_mark(client: &Client, should_provide_date_picker: bool) -> std::io::Result<()> {
-    let input = get_input_for_mark(should_provide_date_picker);
+pub async fn add_mark(client: &Client, date: NaiveDate) -> std::io::Result<()> {
+    let input = get_input_for_mark();
 
     let statement = client.prepare("INSERT INTO marks (title, note, created_at) VALUES ($1, $2, $3) RETURNING id").await.expect("Could not prepare statement");
 
     let _title = &input.title.unwrap_or(String::new());
-    let _created_at = &match input.date {
-        Some(d) => { d.and_hms_opt(0, 0, 0).unwrap() },
-        None => { chrono::Local::now().naive_local() }
-    };
+    let _created_at = &date.and_hms_opt(0, 0, 0);
 
     client.query(&statement, &[_title, &input.note, _created_at]).await.expect("Could not execute query");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod argument;
 #[tokio::main]
 async fn main() {
     config::initialize_config().expect("Could not read config");
-    let _client = db::connect::connect_to_db().await.expect("Could not connect to db");
+    let client = db::connect::connect_to_db().await.expect("Could not connect to db");
 
     let args = match argument::get_arguments() {
         Ok(args) => { args },
@@ -15,13 +15,13 @@ async fn main() {
 
     match args.command {
         argument::command::Command::Mark => {
-            command::mark::add_mark(&_client, false).await.expect("Could not add mark");
+            command::mark::add_mark(&client, false).await.expect("Could not add mark");
         },
         argument::command::Command::Marks => {
-            command::marks::list_marks(&_client, args.date).await.expect("Could not get marks");
+            command::marks::list_marks(&client, args.date).await.expect("Could not get marks");
         },
         argument::command::Command::Unmark => {
-            command::unmark::remove_mark(&_client, args.date).await.expect("Could not remove mark");
+            command::unmark::remove_mark(&client, args.date).await.expect("Could not remove mark");
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,13 @@ async fn main() {
     config::initialize_config().expect("Could not read config");
     let client = db::connect::connect_to_db().await.expect("Could not connect to db");
 
+    let _args = match argument::get_arguments() {
+        Ok(args) => { args },
+        Err(e) => { panic!("Error: {}", e) }
+    };
+
+    return;
+
     let mut arguments = std::env::args();
     arguments.next(); // Skip the first argument
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod argument;
 #[tokio::main]
 async fn main() {
     config::initialize_config().expect("Could not read config");
-    let client = db::connect::connect_to_db().await.expect("Could not connect to db");
+    let _client = db::connect::connect_to_db().await.expect("Could not connect to db");
 
     let _args = match argument::get_arguments() {
         Ok(args) => { args },
@@ -15,68 +15,68 @@ async fn main() {
 
     return;
 
-    let mut arguments = std::env::args();
-    arguments.next(); // Skip the first argument
-
-    let command = arguments.next().expect("Command Expected");
-    match command.as_str() {
-        "mark" => {
-            let should_provide_date_picker = match arguments.next() {
-                Some(t) => {
-                    match t.as_str() {
-                        "--future" => { true },
-                        _ => {
-                            panic!("Error: Invalid argument. Allowed values: --future, or provide no args for today");
-                        }
-                    }
-                },
-                None => { false }
-            };
-
-            command::mark::add_mark(&client, should_provide_date_picker).await.expect("Could not add mark");
-        },
-        "marks" => {
-            let arg = arguments.next();
-            let date = match arg {
-                None => {
-                    /* TODO: Allow to default to --today in config.json */
-                    panic!("Error: No argument found. Allowed values: --today, --date=YYYY-MM-DD");
-                },
-                Some(t) => {
-                    match argument::date::get_date_from_args(t) {
-                        Ok(date) => { date },
-                        Err(e) => {
-                            panic!("Error: {}", e);
-                        }
-                    }
-                }
-            };
-
-            command::marks::list_marks(&client, date).await.expect("Could not get marks");
-        },
-        "unmark" => {
-            let arg = arguments.next();
-            let date = match arg {
-                None => {
-                    /* TODO: Allow to default to --today in config.json */
-                    panic!("Error: No argument found. Allowed values: --today, --date=YYYY-MM-DD");
-                },
-                Some(t) => {
-                    match argument::date::get_date_from_args(t) {
-                        Ok(date) => { date },
-                        Err(e) => {
-                            panic!("Error: {}", e);
-                        }
-                    }
-                }
-            };
-
-
-            command::unmark::remove_mark(&client, date).await.expect("Could not remove mark");
-        },
-        _ => {
-            // Invalid command, print an error message
-            eprintln!("Error: Invalid command. Allowed values: mark");
-        }
-    }
+    // let mut arguments = std::env::args();
+    // arguments.next(); // Skip the first argument
+    //
+    // let command = arguments.next().expect("Command Expected");
+    // match command.as_str() {
+    //     "mark" => {
+    //         let should_provide_date_picker = match arguments.next() {
+    //             Some(t) => {
+    //                 match t.as_str() {
+    //                     "--future" => { true },
+    //                     _ => {
+    //                         panic!("Error: Invalid argument. Allowed values: --future, or provide no args for today");
+    //                     }
+    //                 }
+    //             },
+    //             None => { false }
+    //         };
+    //
+    //         command::mark::add_mark(&client, should_provide_date_picker).await.expect("Could not add mark");
+    //     },
+    //     "marks" => {
+    //         let arg = arguments.next();
+    //         let date = match arg {
+    //             None => {
+    //                 /* TODO: Allow to default to --today in config.json */
+    //                 panic!("Error: No argument found. Allowed values: --today, --date=YYYY-MM-DD");
+    //             },
+    //             Some(t) => {
+    //                 match argument::date::get_date_from_args(t) {
+    //                     Ok(date) => { date },
+    //                     Err(e) => {
+    //                         panic!("Error: {}", e);
+    //                     }
+    //                 }
+    //             }
+    //         };
+    //
+    //         command::marks::list_marks(&client, date).await.expect("Could not get marks");
+    //     },
+    //     "unmark" => {
+    //         let arg = arguments.next();
+    //         let date = match arg {
+    //             None => {
+    //                 /* TODO: Allow to default to --today in config.json */
+    //                 panic!("Error: No argument found. Allowed values: --today, --date=YYYY-MM-DD");
+    //             },
+    //             Some(t) => {
+    //                 match argument::date::get_date_from_args(t) {
+    //                     Ok(date) => { date },
+    //                     Err(e) => {
+    //                         panic!("Error: {}", e);
+    //                     }
+    //                 }
+    //             }
+    //         };
+    //
+    //
+    //         command::unmark::remove_mark(&client, date).await.expect("Could not remove mark");
+    //     },
+    //     _ => {
+    //         // Invalid command, print an error message
+    //         eprintln!("Error: Invalid command. Allowed values: mark");
+    //     }
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,75 +8,20 @@ async fn main() {
     config::initialize_config().expect("Could not read config");
     let _client = db::connect::connect_to_db().await.expect("Could not connect to db");
 
-    let _args = match argument::get_arguments() {
+    let args = match argument::get_arguments() {
         Ok(args) => { args },
         Err(e) => { panic!("Error: {}", e) }
     };
 
-    return;
-
-    // let mut arguments = std::env::args();
-    // arguments.next(); // Skip the first argument
-    //
-    // let command = arguments.next().expect("Command Expected");
-    // match command.as_str() {
-    //     "mark" => {
-    //         let should_provide_date_picker = match arguments.next() {
-    //             Some(t) => {
-    //                 match t.as_str() {
-    //                     "--future" => { true },
-    //                     _ => {
-    //                         panic!("Error: Invalid argument. Allowed values: --future, or provide no args for today");
-    //                     }
-    //                 }
-    //             },
-    //             None => { false }
-    //         };
-    //
-    //         command::mark::add_mark(&client, should_provide_date_picker).await.expect("Could not add mark");
-    //     },
-    //     "marks" => {
-    //         let arg = arguments.next();
-    //         let date = match arg {
-    //             None => {
-    //                 /* TODO: Allow to default to --today in config.json */
-    //                 panic!("Error: No argument found. Allowed values: --today, --date=YYYY-MM-DD");
-    //             },
-    //             Some(t) => {
-    //                 match argument::date::get_date_from_args(t) {
-    //                     Ok(date) => { date },
-    //                     Err(e) => {
-    //                         panic!("Error: {}", e);
-    //                     }
-    //                 }
-    //             }
-    //         };
-    //
-    //         command::marks::list_marks(&client, date).await.expect("Could not get marks");
-    //     },
-    //     "unmark" => {
-    //         let arg = arguments.next();
-    //         let date = match arg {
-    //             None => {
-    //                 /* TODO: Allow to default to --today in config.json */
-    //                 panic!("Error: No argument found. Allowed values: --today, --date=YYYY-MM-DD");
-    //             },
-    //             Some(t) => {
-    //                 match argument::date::get_date_from_args(t) {
-    //                     Ok(date) => { date },
-    //                     Err(e) => {
-    //                         panic!("Error: {}", e);
-    //                     }
-    //                 }
-    //             }
-    //         };
-    //
-    //
-    //         command::unmark::remove_mark(&client, date).await.expect("Could not remove mark");
-    //     },
-    //     _ => {
-    //         // Invalid command, print an error message
-    //         eprintln!("Error: Invalid command. Allowed values: mark");
-    //     }
-    // }
+    match args.command {
+        argument::command::Command::Mark => {
+            command::mark::add_mark(&_client, false).await.expect("Could not add mark");
+        },
+        argument::command::Command::Marks => {
+            command::marks::list_marks(&_client, args.date).await.expect("Could not get marks");
+        },
+        argument::command::Command::Unmark => {
+            command::unmark::remove_mark(&_client, args.date).await.expect("Could not remove mark");
+        },
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
 
     match args.command {
         argument::command::Command::Mark => {
-            command::mark::add_mark(&client, false).await.expect("Could not add mark");
+            command::mark::add_mark(&client, args.date).await.expect("Could not add mark");
         },
         argument::command::Command::Marks => {
             command::marks::list_marks(&client, args.date).await.expect("Could not get marks");


### PR DESCRIPTION
Re: #1 

This PR:
- Modifies the fn to parse the date, to return a set date. This may happen either from the user of `--today`, or by showing a date select after using `--past` or `--future`
- Adds enum for commands to allow for better type checking. Possible improvement: Add the parameters required for each command as part of the enum variants itself