### PR TITLE
refactor queries for database access

### DIFF
--- a/src/command/mark.rs
+++ b/src/command/mark.rs
@@ -1,13 +1,14 @@
 use std::ffi::OsStr;
 use chrono::{NaiveDate};
 use inquire::{Editor, required, Text};
-use tokio_postgres::Client;
 use crate::config;
+use crate::db::Database;
+use tokio_postgres::{Error};
 
 #[derive(Debug)]
-struct InputMark {
-    title: Option<String>,
-    note: String,
+pub struct InputMark {
+    pub title: Option<String>,
+    pub note: String,
 }
 
 fn get_input_for_mark() -> InputMark {
@@ -51,15 +52,12 @@ fn get_input_for_mark() -> InputMark {
     }
 }
 
-pub async fn add_mark(client: &Client, date: NaiveDate) -> std::io::Result<()> {
+pub async fn add_mark(db: &Database, date: NaiveDate) -> Result<(), Error> {
     let input = get_input_for_mark();
-
-    let statement = client.prepare("INSERT INTO marks (title, note, created_at) VALUES ($1, $2, $3) RETURNING id").await.expect("Could not prepare statement");
-
     let _title = &input.title.unwrap_or(String::new());
-    let _created_at = &date.and_hms_opt(0, 0, 0);
+    let _created_at = &date.and_hms_opt(0, 0, 0).unwrap();
 
-    client.query(&statement, &[_title, &input.note, _created_at]).await.expect("Could not execute query");
+    db.add_mark(_created_at, _title, &input.note).await.expect("Could not execute query");
 
     Ok(())
 }

--- a/src/command/mark.rs
+++ b/src/command/mark.rs
@@ -16,7 +16,7 @@ fn get_input_for_mark() -> InputMark {
     let mark_style = &config.mark_style;
     let editor = &config.editor;
 
-    let input_mark = match mark_style {
+    match mark_style {
         config::MarkStyle::Default => {
             let _note = Text::new("Mark")
                 .with_placeholder("Some text to be marked")
@@ -48,9 +48,7 @@ fn get_input_for_mark() -> InputMark {
                 note: _note,
             }
         },
-    };
-
-    return input_mark;
+    }
 }
 
 pub async fn add_mark(client: &Client, date: NaiveDate) -> std::io::Result<()> {

--- a/src/command/marks.rs
+++ b/src/command/marks.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 use chrono::{NaiveDate, NaiveDateTime};
-use tokio_postgres::{Client, Row};
+use tokio_postgres::{Row, Error};
+use crate::db::Database;
 
 #[derive(Debug)]
 pub struct Mark {
@@ -16,11 +17,8 @@ impl Display for Mark {
     }
 }
 
-pub async fn read_marks(client: &Client, date: NaiveDate) -> std::io::Result<Vec<Mark>> {
-    let statement = client.prepare("SELECT * FROM Marks WHERE DATE(created_at)=$1 ORDER BY created_at").await.expect("Could not prepare statement");
-    let _rows: Vec<Row> = client.query(&statement, &[&date]).await.expect("Could not execute query");
-
-    let rows: Vec<Mark> = _rows.iter().map(|row| {
+pub async fn transform_marks(rows: &Vec<Row>) -> Result<Vec<Mark>, Error> {
+    let marks: Vec<Mark> = rows.iter().map(|row| {
         let id: i8 = i8::try_from(row.get::<&str, i64>("id")).unwrap();
         let title = row.get::<&str, &str>("title").to_string();
         let note = row.get::<&str, &str>("note").to_string();
@@ -29,11 +27,13 @@ pub async fn read_marks(client: &Client, date: NaiveDate) -> std::io::Result<Vec
         return Mark { id, title, note, created_at }
     }).collect();
 
-    return Ok(rows)
+    Ok(marks)
 }
 
-pub async fn list_marks(client: &Client, date: NaiveDate) -> std::io::Result<()> {
-    let marks = read_marks(client, date).await.unwrap();
+pub async fn list_marks(db: &Database, date: &NaiveDate) -> Result<(), Error> {
+    let _marks = db.read_marks_by_date(date).await?;
+    let marks = transform_marks(&_marks).await?;
+
     if marks.len() == 0 {
         println!("You have no marks for {}", date.format("%B %e, %Y").to_string());
         return Ok(());

--- a/src/command/marks.rs
+++ b/src/command/marks.rs
@@ -1,38 +1,11 @@
-use std::fmt::{Display, Formatter};
-use chrono::{NaiveDate, NaiveDateTime};
-use tokio_postgres::{Row, Error};
+use chrono::{NaiveDate};
+use tokio_postgres::{Error};
 use crate::db::Database;
-
-#[derive(Debug)]
-pub struct Mark {
-    pub id: i8,
-    title: String,
-    note: String,
-    created_at: NaiveDateTime,
-}
-
-impl Display for Mark {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}\n", self.created_at.format("%H:%M").to_string(), self.note)
-    }
-}
-
-pub async fn transform_marks(rows: &Vec<Row>) -> Result<Vec<Mark>, Error> {
-    let marks: Vec<Mark> = rows.iter().map(|row| {
-        let id: i8 = i8::try_from(row.get::<&str, i64>("id")).unwrap();
-        let title = row.get::<&str, &str>("title").to_string();
-        let note = row.get::<&str, &str>("note").to_string();
-        let created_at = row.get::<&str, NaiveDateTime>("created_at");
-
-        return Mark { id, title, note, created_at }
-    }).collect();
-
-    Ok(marks)
-}
+use crate::util::mark::Mark;
 
 pub async fn list_marks(db: &Database, date: &NaiveDate) -> Result<(), Error> {
     let _marks = db.read_marks_by_date(date).await?;
-    let marks = transform_marks(&_marks).await?;
+    let marks: Vec<Mark> = _marks.iter().map(Mark::new_from_row).collect();
 
     if marks.len() == 0 {
         println!("You have no marks for {}", date.format("%B %e, %Y").to_string());

--- a/src/command/unmark.rs
+++ b/src/command/unmark.rs
@@ -2,8 +2,9 @@ use chrono::NaiveDate;
 use inquire::{Confirm, MultiSelect};
 use inquire::list_option::ListOption;
 use inquire::validator::Validation;
-use tokio_postgres::Client;
-use crate::command::marks::Mark;
+use tokio_postgres::Error;
+use crate::command::marks::{Mark, transform_marks};
+use crate::db::Database;
 
 struct InputUnmark {
     ids: Vec<i64>,
@@ -33,23 +34,25 @@ fn get_input_for_unmark(marks: Vec<Mark>) -> InputUnmark {
     }
 }
 
-pub async fn remove_mark(client: &Client, date: NaiveDate) -> std::io::Result<()> {
-    let _marks = crate::command::marks::read_marks(client, date).await.expect("Unable to read marks");
+pub async fn remove_mark(db: &Database, date: &NaiveDate) -> Result<(), Error> {
+    let _marks = db.read_marks_by_date(date).await?;
     if _marks.len() == 0 {
         println!("You have no marks for {}", date.format("%B %e, %Y").to_string());
         return Ok(());
     }
 
+    let marks = transform_marks(&_marks).await?;
+
     println!("You marked the following on {}:", date.format("%B %e, %Y").to_string());
-    let input = get_input_for_unmark(_marks);
+    let input = get_input_for_unmark(marks);
 
     if !input.confirm {
         return Ok(());
     }
 
-    let statement = client.prepare("DELETE FROM marks WHERE id = $1").await.expect("Could not prepare statement");
+    let statement = db.client.prepare("DELETE FROM marks WHERE id = $1").await.expect("Could not prepare statement");
     for id in input.ids {
-        client.query(&statement, &[&id]).await.expect("Could not remove mark");
+        db.client.query(&statement, &[&id]).await.expect("Could not remove mark");
     }
 
     Ok(())

--- a/src/command/unmark.rs
+++ b/src/command/unmark.rs
@@ -3,8 +3,8 @@ use inquire::{Confirm, MultiSelect};
 use inquire::list_option::ListOption;
 use inquire::validator::Validation;
 use tokio_postgres::Error;
-use crate::command::marks::{Mark, transform_marks};
 use crate::db::Database;
+use crate::util::mark::Mark;
 
 struct InputUnmark {
     ids: Vec<i64>,
@@ -41,7 +41,7 @@ pub async fn remove_mark(db: &Database, date: &NaiveDate) -> Result<(), Error> {
         return Ok(());
     }
 
-    let marks = transform_marks(&_marks).await?;
+    let marks = _marks.iter().map(Mark::new_from_row).collect::<Vec<Mark>>();
 
     println!("You marked the following on {}:", date.format("%B %e, %Y").to_string());
     let input = get_input_for_unmark(marks);

--- a/src/command/unmark.rs
+++ b/src/command/unmark.rs
@@ -50,9 +50,8 @@ pub async fn remove_mark(db: &Database, date: &NaiveDate) -> Result<(), Error> {
         return Ok(());
     }
 
-    let statement = db.client.prepare("DELETE FROM marks WHERE id = $1").await.expect("Could not prepare statement");
-    for id in input.ids {
-        db.client.query(&statement, &[&id]).await.expect("Could not remove mark");
+    for id in input.ids.iter() {
+        db.delete_mark_by_id(id).await?;
     }
 
     Ok(())

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,4 @@
-use tokio_postgres::{Error};
+use tokio_postgres::{Error, Row};
 
 mod connect;
 
@@ -8,11 +8,17 @@ pub struct Database {
 
 impl Database {
     pub async fn add_mark(&self, date: &chrono::NaiveDateTime, title: &String, note: &String) -> Result<(), Error> {
-        let statement = self.client.prepare("INSERT INTO marks (title, note, created_at) VALUES ($1, $2, $3) RETURNING id").await?;
-
+        let statement = self.client.prepare("INSERT INTO marks (title, note, created_at) VALUES ($1, $2, $3)").await?;
         self.client.query(&statement, &[title, note, date]).await?;
 
         Ok(())
+    }
+
+    pub async fn read_marks_by_date(&self, date: &chrono::NaiveDate) -> Result<Vec<Row>, Error> {
+        let statement = self.client.prepare("SELECT * FROM Marks WHERE DATE(created_at)=$1 ORDER BY created_at").await?;
+        let rows: Vec<Row> = self.client.query(&statement, &[&date]).await?;
+
+        Ok(rows)
     }
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,6 +6,16 @@ pub struct Database {
     pub client: tokio_postgres::Client,
 }
 
+impl Database {
+    pub async fn add_mark(&self, date: &chrono::NaiveDateTime, title: &String, note: &String) -> Result<(), Error> {
+        let statement = self.client.prepare("INSERT INTO marks (title, note, created_at) VALUES ($1, $2, $3) RETURNING id").await?;
+
+        self.client.query(&statement, &[title, note, date]).await?;
+
+        Ok(())
+    }
+}
+
 pub async fn get_database() -> Result<Database, Error> {
     let client = connect::connect_to_db().await?;
     Ok(Database { client })

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,1 +1,12 @@
-pub mod connect;
+use tokio_postgres::{Error};
+
+mod connect;
+
+pub struct Database {
+    pub client: tokio_postgres::Client,
+}
+
+pub async fn get_database() -> Result<Database, Error> {
+    let client = connect::connect_to_db().await?;
+    Ok(Database { client })
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -20,6 +20,13 @@ impl Database {
 
         Ok(rows)
     }
+
+    pub async fn delete_mark_by_id(&self, id: &i64) -> Result<(), Error> {
+        let statement = self.client.prepare("DELETE FROM marks WHERE id = $1").await?;
+        self.client.query(&statement, &[id]).await?;
+
+        Ok(())
+    }
 }
 
 pub async fn get_database() -> Result<Database, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ async fn main() {
             command::mark::add_mark(&db, args.date).await.expect("Could not add mark");
         },
         argument::command::Command::Marks => {
-            command::marks::list_marks(&db.client, args.date).await.expect("Could not get marks");
+            command::marks::list_marks(&db, &args.date).await.expect("Could not get marks");
         },
         argument::command::Command::Unmark => {
-            command::unmark::remove_mark(&db.client, args.date).await.expect("Could not remove mark");
+            command::unmark::remove_mark(&db, &args.date).await.expect("Could not remove mark");
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod argument;
 #[tokio::main]
 async fn main() {
     config::initialize_config().expect("Could not read config");
-    let client = db::connect::connect_to_db().await.expect("Could not connect to db");
+    let db = db::get_database().await.expect("Could not connect to database");
 
     let args = match argument::get_arguments() {
         Ok(args) => { args },
@@ -15,13 +15,13 @@ async fn main() {
 
     match args.command {
         argument::command::Command::Mark => {
-            command::mark::add_mark(&client, args.date).await.expect("Could not add mark");
+            command::mark::add_mark(&db.client, args.date).await.expect("Could not add mark");
         },
         argument::command::Command::Marks => {
-            command::marks::list_marks(&client, args.date).await.expect("Could not get marks");
+            command::marks::list_marks(&db.client, args.date).await.expect("Could not get marks");
         },
         argument::command::Command::Unmark => {
-            command::unmark::remove_mark(&client, args.date).await.expect("Could not remove mark");
+            command::unmark::remove_mark(&db.client, args.date).await.expect("Could not remove mark");
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod command;
 mod db;
 mod config;
 mod argument;
+mod util;
 
 #[tokio::main]
 async fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
 
     match args.command {
         argument::command::Command::Mark => {
-            command::mark::add_mark(&db.client, args.date).await.expect("Could not add mark");
+            command::mark::add_mark(&db, args.date).await.expect("Could not add mark");
         },
         argument::command::Command::Marks => {
             command::marks::list_marks(&db.client, args.date).await.expect("Could not get marks");

--- a/src/util/mark.rs
+++ b/src/util/mark.rs
@@ -1,0 +1,28 @@
+use std::fmt::{Display, Formatter};
+use tokio_postgres::{Row};
+use chrono::NaiveDateTime;
+
+#[derive(Debug)]
+pub struct Mark {
+    pub id: i8,
+    title: String,
+    pub note: String,
+    pub created_at: NaiveDateTime,
+}
+
+impl Display for Mark {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}\n", self.created_at.format("%H:%M").to_string(), self.note)
+    }
+}
+
+impl Mark {
+    pub fn new_from_row(row: &Row) -> Self {
+        let id: i8 = i8::try_from(row.get::<&str, i64>("id")).unwrap();
+        let title = row.get::<&str, &str>("title").to_string();
+        let note = row.get::<&str, &str>("note").to_string();
+        let created_at = row.get::<&str, NaiveDateTime>("created_at");
+
+        Mark { id, title, note, created_at }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod mark;


### PR DESCRIPTION
Re #4 

This PR:
- extracts the transformer to convert d row to mark struct into its own file
- creates a struct to wrap the db client and related queries
- cleans up the existing usages of client and queries inside command files