### PR TITLE
add config option for defaults

### DIFF
--- a/src/argument/date.rs
+++ b/src/argument/date.rs
@@ -14,7 +14,7 @@ use crate::config::{CONFIG, DefaultDateTimeArg};
  *
  * An `Option` containing the date, or `None` if the argument is not a date
  */
-pub fn get_date_from_args(arg: &String) -> Result<Option<NaiveDate>, &'static str> {
+fn get_date_from_args(arg: &String) -> Result<Option<NaiveDate>, &'static str> {
     let date_option = match arg.starts_with("--today") {
         false => { None }
         true => {
@@ -63,7 +63,15 @@ fn get_date_from_user() -> NaiveDate {
  *
  * The date to use
  */
-pub fn get_date() -> NaiveDate {
+pub fn get_date(args: &Vec<String>) -> NaiveDate {
+    let date_arg = args.iter().filter_map(|arg| {
+        get_date_from_args(arg).ok()?
+    }).last();
+
+    if date_arg.is_some() {
+        return date_arg.unwrap();
+    }
+
     let guard = CONFIG.lock().unwrap();
     let config = guard.as_ref().unwrap();
     let default_date_mode = &config.default_date;

--- a/src/argument/date.rs
+++ b/src/argument/date.rs
@@ -1,5 +1,7 @@
 use inquire::DateSelect;
 use chrono::{Duration, NaiveDate};
+use crate::config::{CONFIG, DefaultDateTimeArg};
+
 
 /**
  * Get the date from the command line arguments
@@ -50,6 +52,28 @@ pub fn get_date_from_args(arg: &String) -> Result<Option<NaiveDate>, &'static st
  *
  * The date selected by the user
  */
-pub fn get_date_from_user() -> NaiveDate {
+fn get_date_from_user() -> NaiveDate {
     DateSelect::new("Date").prompt().unwrap()
+}
+
+/**
+ * Get the date to use considering default date mode
+ *
+ * # Returns
+ *
+ * The date to use
+ */
+pub fn get_date() -> NaiveDate {
+    let guard = CONFIG.lock().unwrap();
+    let config = guard.as_ref().unwrap();
+    let default_date_mode = &config.default_date;
+
+    match default_date_mode {
+        DefaultDateTimeArg::Current => {
+            chrono::Local::now().date_naive()
+        },
+        DefaultDateTimeArg::Input => {
+            get_date_from_user()
+        },
+    }
 }

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -33,26 +33,8 @@ pub fn get_arguments() -> Result<Arguments, String> {
     let command = command::get_command_from_args(potential_command)?;
 
     let remaining_args: Vec<String> = arguments.collect();
-
-    let date_arg = remaining_args.iter().filter_map(|arg| {
-        date::get_date_from_args(arg).ok()?
-    }).last();
-
-    let time_arg = remaining_args.iter().filter_map(|arg| {
-        time::get_time_from_args(arg).ok()?
-    }).last();
-
-    /* TODO: Refactor the following code so that UI is not used in the argument module */
-    let date = date_arg.unwrap_or_else(date::get_date);
-
-    /*
-     * We only want to prompt the user for a time if the command is "mark",
-     * otherwise return a default time
-     */
-    let time = time_arg.unwrap_or(match command {
-        command::Command::Mark => time::get_time(),
-        _ => NaiveTime::from_hms_opt(0, 0, 0).unwrap()
-    });
+    let date = date::get_date(&remaining_args);
+    let time = time::get_time(&remaining_args);
 
     let args = Arguments {
         command,

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -43,7 +43,7 @@ pub fn get_arguments() -> Result<Arguments, String> {
     }).last();
 
     /* TODO: Refactor the following code so that UI is not used in the argument module */
-    let date = date_arg.unwrap_or_else(date::get_date_from_user);
+    let date = date_arg.unwrap_or_else(date::get_date);
 
     /*
      * We only want to prompt the user for a time if the command is "mark",

--- a/src/argument/mod.rs
+++ b/src/argument/mod.rs
@@ -50,7 +50,7 @@ pub fn get_arguments() -> Result<Arguments, String> {
      * otherwise return a default time
      */
     let time = time_arg.unwrap_or(match command {
-        command::Command::Mark => time::get_time_from_user(),
+        command::Command::Mark => time::get_time(),
         _ => NaiveTime::from_hms_opt(0, 0, 0).unwrap()
     });
 

--- a/src/argument/time.rs
+++ b/src/argument/time.rs
@@ -1,5 +1,6 @@
-use chrono::{NaiveTime};
+use chrono::{NaiveDate, NaiveTime};
 use inquire::Text;
+use crate::config::{CONFIG, DefaultDateTimeArg};
 use crate::util::time::parse_time_from_string;
 
 /**
@@ -41,10 +42,32 @@ pub fn get_time_from_args(arg: &String) -> Result<Option<NaiveTime>, &'static st
  *
  * The time selected by the user
  */
-pub fn get_time_from_user() -> NaiveTime {
+fn get_time_from_user() -> NaiveTime {
     let time = Text::new("Time")
         .with_placeholder("Time for the mark (HH:MM)")
         .prompt().unwrap();
 
     parse_time_from_string(&time.to_string()).expect("Could not parse time from user input")
+}
+
+/**
+ * Get the time to use considering default time mode
+ *
+ * # Returns
+ *
+ * The time to use
+ */
+pub fn get_time() -> NaiveTime {
+    let guard = CONFIG.lock().unwrap();
+    let config = guard.as_ref().unwrap();
+    let default_time_mode = &config.default_time;
+
+    match default_time_mode {
+        DefaultDateTimeArg::Current => {
+            chrono::Local::now().time()
+        },
+        DefaultDateTimeArg::Input => {
+            get_time_from_user()
+        },
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,14 +5,16 @@ use serde::{Deserialize, Serialize};
 use lazy_static::lazy_static;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
-pub enum MarkStyle {
-    Default,
-    Extended,
+pub enum DefaultDateTimeArg {
+    Current,
+    Input,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     pub connect_string: String,
+    pub default_date: DefaultDateTimeArg,
+    pub default_time: DefaultDateTimeArg,
 }
 
 lazy_static! {


### PR DESCRIPTION
This PR adds two new properties to `config.json` that allows the user to specify what should happen when no date and time args are provided.

These properties are called: `default_date` and `default_time` and each can have a value of either `Current` or `Input`.

Addresses #10 